### PR TITLE
Add cross-repo build workflows

### DIFF
--- a/.github/workflows/build-ylem-container-prod-env.yaml
+++ b/.github/workflows/build-ylem-container-prod-env.yaml
@@ -1,0 +1,22 @@
+name: Trigger internal azimuth-cli prod build
+
+on:
+  push:
+    branches:
+      - solaris
+
+jobs:
+  trigger-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository dispatch to ylem (prod)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { GITHUB_TOKEN } = process.env;
+            await github.repos.createDispatchEvent({
+              owner: 'tloncorp',
+              repo: 'ylem',
+              event_type: 'prod-breach-ship-docker',
+              client_payload: { branch: 'main' }
+            });

--- a/.github/workflows/build-ylem-container-prod-env.yaml
+++ b/.github/workflows/build-ylem-container-prod-env.yaml
@@ -1,6 +1,7 @@
 name: Trigger internal azimuth-cli prod build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - solaris

--- a/.github/workflows/build-ylem-container-test-env.yaml
+++ b/.github/workflows/build-ylem-container-test-env.yaml
@@ -1,0 +1,20 @@
+name: Trigger internal azimuth-cli prod build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository dispatch to ylem (test)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { GITHUB_TOKEN } = process.env;
+            await github.repos.createDispatchEvent({
+              owner: 'tloncorp',
+              repo: 'ylem',
+              event_type: 'test-breach-ship-docker',
+              client_payload: { branch: 'main' }
+            });


### PR DESCRIPTION
- Adds jobs to cross-build in ylem repo actions on commits to `solaris` branch for prod, or manually dispatched for test